### PR TITLE
Expect and operate in Utf8

### DIFF
--- a/test/WhitespaceSpec.hs
+++ b/test/WhitespaceSpec.hs
@@ -20,6 +20,14 @@ spec = do
             , foPaths = [] -- Unused
             }
 
+    describe "formatPath" $ do
+        it "doesn't incorrectly format non-utf8" $ do
+            let path = "test/fixtures/non-utf8.yaml"
+
+            runSimpleApp (formatPath opts path) `shouldThrow` \case
+                UnableToRead _ -> True
+                _ -> False
+
     describe "format" $ do
         it "strips trailing whitespace from the given content" $ do
             let content = mconcat

--- a/test/fixtures/non-utf8.yaml
+++ b/test/fixtures/non-utf8.yaml
@@ -1,0 +1,2 @@
+- uuid: 9ee10563
+  text: What?Â


### PR DESCRIPTION
Char 160 is (apparently) non-breaking space in win-1252, so operating in
ByteString finds it (C8.isSpace) and trims it. But this results in an
invalid character, visible as "Â" in some contexts.

We can really only do this in Uf8, so let's just expect that. We already
have exception handling (i.e. --strict) for our CRLF check, so any
exceptions trying to read files (including Utf8 errors) can be naturally
captured there as a new case.